### PR TITLE
Do not modify package.json

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -535,7 +535,7 @@ class DynatraceOneAgentPlugin {
 
 		return new Promise((resolve, reject) => {
 			this.log(`Installing Dynatrace oneagent npm module`);
-			const args = [ this.qualifiedNpmModuleName ];
+			const args = [ this.qualifiedNpmModuleName, "--no-save" ];
 
 			Npm.commands.install(args, (err) => {
 				if (!err) {


### PR DESCRIPTION
In recent versions of npm, the package.json file is modified on package installs. The plugin should not modify any user files that are not necessary to modify. Adding the --no-save option prevents this behavior.